### PR TITLE
adds a workaround to access nodes with node

### DIFF
--- a/uesgraphs/uesgraph.py
+++ b/uesgraphs/uesgraph.py
@@ -122,6 +122,10 @@ class UESGraph(nx.Graph):
         self.pipeIDs = []
 
     @property
+    def node(self):
+        return self.nodes
+
+    @property
     def positions(self):
         for node in self.nodes(data=True):
             if node[0] is not None:


### PR DESCRIPTION
The current workaround in networkx was removed which enabled access
of nodes with the node attribute. This commit adds the workaround
in uesgraphs.
fixes #17