### PR TITLE
Fix/issue50 cmap visuals

### DIFF
--- a/uesgraphs/examples/interactive2.ipynb
+++ b/uesgraphs/examples/interactive2.ipynb
@@ -2,40 +2,32 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collecting ipywidgets\n",
-      "  Using cached ipywidgets-8.1.5-py3-none-any.whl.metadata (2.3 kB)\n",
-      "Requirement already satisfied: comm>=0.1.3 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipywidgets) (0.2.2)\n",
-      "Requirement already satisfied: ipython>=6.1.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipywidgets) (9.0.2)\n",
-      "Requirement already satisfied: traitlets>=4.3.1 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipywidgets) (5.14.3)\n",
-      "Collecting widgetsnbextension~=4.0.12 (from ipywidgets)\n",
-      "  Using cached widgetsnbextension-4.0.13-py3-none-any.whl.metadata (1.6 kB)\n",
-      "Collecting jupyterlab-widgets~=3.0.12 (from ipywidgets)\n",
-      "  Using cached jupyterlab_widgets-3.0.13-py3-none-any.whl.metadata (4.1 kB)\n",
-      "Requirement already satisfied: colorama in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.4.6)\n",
-      "Requirement already satisfied: decorator in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)\n",
-      "Requirement already satisfied: ipython-pygments-lexers in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)\n",
-      "Requirement already satisfied: jedi>=0.16 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)\n",
-      "Requirement already satisfied: matplotlib-inline in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.1.7)\n",
-      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (3.0.50)\n",
-      "Requirement already satisfied: pygments>=2.4.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (2.19.1)\n",
-      "Requirement already satisfied: stack_data in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)\n",
-      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from jedi>=0.16->ipython>=6.1.0->ipywidgets) (0.8.4)\n",
-      "Requirement already satisfied: wcwidth in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.2.13)\n",
-      "Requirement already satisfied: executing>=1.2.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (2.2.0)\n",
-      "Requirement already satisfied: asttokens>=2.1.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (3.0.0)\n",
-      "Requirement already satisfied: pure-eval in d:\\rka-lko\\conda\\envs\\uesgraphs_git1\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (0.2.3)\n",
-      "Using cached ipywidgets-8.1.5-py3-none-any.whl (139 kB)\n",
-      "Using cached jupyterlab_widgets-3.0.13-py3-none-any.whl (214 kB)\n",
-      "Using cached widgetsnbextension-4.0.13-py3-none-any.whl (2.3 MB)\n",
-      "Installing collected packages: widgetsnbextension, jupyterlab-widgets, ipywidgets\n",
-      "Successfully installed ipywidgets-8.1.5 jupyterlab-widgets-3.0.13 widgetsnbextension-4.0.13\n"
+      "Requirement already satisfied: ipywidgets in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (8.1.5)\n",
+      "Requirement already satisfied: comm>=0.1.3 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipywidgets) (0.2.2)\n",
+      "Requirement already satisfied: ipython>=6.1.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipywidgets) (9.0.2)\n",
+      "Requirement already satisfied: traitlets>=4.3.1 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipywidgets) (5.14.3)\n",
+      "Requirement already satisfied: widgetsnbextension~=4.0.12 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipywidgets) (4.0.13)\n",
+      "Requirement already satisfied: jupyterlab-widgets~=3.0.12 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipywidgets) (3.0.13)\n",
+      "Requirement already satisfied: colorama in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.4.6)\n",
+      "Requirement already satisfied: decorator in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)\n",
+      "Requirement already satisfied: ipython-pygments-lexers in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)\n",
+      "Requirement already satisfied: jedi>=0.16 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)\n",
+      "Requirement already satisfied: matplotlib-inline in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.1.7)\n",
+      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (3.0.50)\n",
+      "Requirement already satisfied: pygments>=2.4.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (2.19.1)\n",
+      "Requirement already satisfied: stack_data in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from jedi>=0.16->ipython>=6.1.0->ipywidgets) (0.8.4)\n",
+      "Requirement already satisfied: wcwidth in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.2.13)\n",
+      "Requirement already satisfied: executing>=1.2.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (2.2.0)\n",
+      "Requirement already satisfied: asttokens>=2.1.0 in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (3.0.0)\n",
+      "Requirement already satisfied: pure-eval in d:\\rka-lko\\conda\\envs\\uesgraphs_git_data_explo\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (0.2.3)\n"
      ]
     }
    ],
@@ -47,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,16 +67,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "\n",
     "\n",
     "\n",
-    "\n",
-    "json = r\"D:\\rka-lko\\git\\ebc1041_eon_g24_substation_retrofit_ibbenbueren_ues\\dhc_model\\workspace\\g24_ibbenburen_heatpump_uesgraphs.json\"#os.path.join(dir_ues, \"workspace\", \"e11\", \"inputs\",\"test_modelgen\", \"Pinola\", \"nodes.json\")\n",
-    "sim_data = r\"D:\\rka-lko\\work\\2024_11_Rahul_Ibb\\results\\HP_dT10K_S45.gzip\"#os.path.join(dir_ues,\"uesgraphs\",\"data\",\"Pinola_low_temp_network_inputs.mat\")\n",
+    "dir_ues =r\"D:\\rka-lko\\git\\uesgraphs\"\n",
+    "json = os.path.join(dir_ues, \"workspace\", \"e11\", \"inputs\",\"test_modelgen\", \"Pinola\", \"nodes.json\")\n",
+    "sim_data = os.path.join(dir_ues,\"uesgraphs\",\"data\",\"Pinola_low_temp_network_inputs.mat\")\n",
     "\n",
     "name=\"Ibbenbüren\"\n",
     "\n",
@@ -94,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -103,9 +95,9 @@
      "text": [
       "read nodes...\n",
       "******\n",
-      " input_ids were {'buildings': None, 'nodes': '8d4751a2-2ccf-4e5d-a707-7fc925859f47', 'pipes': None, 'supplies': None}\n",
+      " input_ids were {'buildings': None, 'nodes': '24f91801-215e-4b3d-9426-4ec51de13368', 'pipes': None, 'supplies': None}\n",
       "...finished\n",
-      "Processing: D:\\rka-lko\\work\\2024_11_Rahul_Ibb\\results\\HP_dT10K_S45.gzip\n",
+      "Processing: D:\\rka-lko\\git\\uesgraphs\\uesgraphs\\data\\Pinola_low_temp_network_inputs.gzip\n",
       "Assignment of pressure to nodes completed\n"
      ]
     }
@@ -126,13 +118,13 @@
     "graph = analyze.assign_data_to_uesgraphs(graph,sim_data = sim_data,\n",
     "                                            start_date=start_date,\n",
     "                                            end_date=end_date,\n",
-    "                                            aixlib_version=\"2.0.0\") #aixlib version is needed to assign data properly\n",
+    "                                            aixlib_version=\"2.1.0\") #aixlib version is needed to assign data properly\n",
     "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,6 +289,13 @@
     "        continuous_update=False,\n",
     "        orientation='horizontal',\n",
     "        readout=True\n",
+    "    )\n",
+    "    \n",
+    "    colormap_widget = widgets.Dropdown(\n",
+    "    options=['viridis', 'coolwarm', 'RdYlGn', 'plasma', 'Blues', 'Reds', 'inferno'],\n",
+    "    value='viridis',\n",
+    "    description='Colormap:',\n",
+    "    disabled=False\n",
     "    )\n",
     "    \n",
     "    # Create dedicated output area for visualization\n",
@@ -591,6 +590,7 @@
     "                            scaling_factor=scaling_factor_widget.value,\n",
     "                            scaling_factor_diameter=scaling_diameter_widget.value,\n",
     "                            label_size=label_size_widget.value,\n",
+    "                            cmap=colormap_widget.value,\n",
     "                            ylabel= f\"{attr['name']} [{attr['unit']}]\",\n",
     "                            generic_intensive_size=\"to_plot\",\n",
     "                            save_as=save_path,\n",
@@ -616,7 +616,7 @@
     "    single_tab = widgets.VBox([\n",
     "        widgets.HTML(\"<h3>Visualization Parameters</h3>\"),\n",
     "        widgets.HBox([scaling_factor_widget, scaling_diameter_widget]),\n",
-    "        widgets.HBox([label_size_widget, update_button]),\n",
+    "        widgets.HBox([label_size_widget, colormap_widget, update_button]),\n",
     "        widgets.HBox([save_checkbox, filename_input]),\n",
     "        widgets.HTML(\"<h4>Visualization Output</h4>\"),\n",
     "        output_area\n",
@@ -652,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,13 +1533,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "131515053d6e420ebe805d45a3891bff",
+       "model_id": "49f276bd2ce644f780f02cd2d68282e5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1573,13 +1573,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0cff46350ce94d9186f170d22a0e9efa",
+       "model_id": "9b67639d26e743d0884d69d16744daac",
        "version_major": 2,
        "version_minor": 0
       },

--- a/uesgraphs/visuals.py
+++ b/uesgraphs/visuals.py
@@ -310,7 +310,8 @@ class Visuals(object):
         generic_intensive_size=None,
         generic_extensive_size=None,
         minmax = False,
-        zero_alpha = 1
+        zero_alpha = 1,
+        cmap = "viridis",
     ):
         """Creates the plot setup, that can be shown or saved to file
 
@@ -370,7 +371,11 @@ class Visuals(object):
         zero_alpha: float
             Alpha value to paint certain edges transparent. Look at docstring
             of paint_edges_extensive_sizes for more information
-
+        cmap : str, optional
+            Name of the colormap to use for visualization (default='viridis').
+            Common options include 'viridis', 'coolwarm', 'RdYlGn', 'plasma', 
+            'Blues'. For temperature data, 'coolwarm' or 'RdYlGn' provide 
+            intuitive red=hot, blue=cold color semantics.
         Returns
         -------
         ax : maplotlib ax object
@@ -741,7 +746,8 @@ class Visuals(object):
                 key="mass_flow",
                 minmax=minmaxmflow,
                 scaling_factor_diameter=scaling_factor_diameter,
-                zero_alpha=zero_alpha
+                zero_alpha=zero_alpha,
+                cmap = cmap
             )
         
         if show_press_drop_flows is True:
@@ -750,7 +756,8 @@ class Visuals(object):
                 key="press_drop_flow",
                 minmax=minmaxmpressdrop,
                 scaling_factor_diameter=scaling_factor_diameter,
-                zero_alpha=zero_alpha
+                zero_alpha=zero_alpha,
+                cmap = cmap
             )
         
         if show_temperature_drop is True:   
@@ -759,7 +766,8 @@ class Visuals(object):
                 key="temperature_drop",
                 minmax=minmaxmtempdrop,
                 scaling_factor_diameter=scaling_factor_diameter,
-                zero_alpha=zero_alpha
+                zero_alpha=zero_alpha,
+                cmap = cmap
             )
 
         if show_velocity is True:
@@ -768,7 +776,8 @@ class Visuals(object):
                 key="velocity",
                 minmax=minmaxmvelocity,
                 scaling_factor_diameter=scaling_factor_diameter,
-                zero_alpha=zero_alpha
+                zero_alpha=zero_alpha,
+                cmap = cmap
             )
 
         #Plotting of intensive sizes
@@ -777,14 +786,16 @@ class Visuals(object):
                 ax,
                 "temperature_supply",
                 scaling_factor_diameter=scaling_factor_diameter,
-                minmax=minmaxtemp
+                minmax=minmaxtemp,
+                cmap = cmap
             )
         if show_press_flows is True:
             self._paint_edges_intensive_sizes(
                 ax,
                 key="press_flow",
                 scaling_factor_diameter=scaling_factor_diameter,
-                minmax=minmaxmpress
+                minmax=minmaxmpress,
+                cmap = cmap
             )
 
         if show_diameters is True:
@@ -797,7 +808,8 @@ class Visuals(object):
                 ax,
                 key = generic_intensive_size,
                 scaling_factor_diameter=scaling_factor_diameter,
-                minmax=minmax
+                minmax=minmax,
+                cmap = cmap
             )
         if generic_extensive_size is not None:
             self._paint_edges_extensive_sizes(
@@ -805,7 +817,8 @@ class Visuals(object):
                 key = generic_extensive_size,
                 minmax=minmax,
                 scaling_factor_diameter=scaling_factor_diameter,
-                zero_alpha=zero_alpha
+                zero_alpha=zero_alpha,
+                cmap = cmap
             )
         
        
@@ -987,7 +1000,8 @@ class Visuals(object):
         generic_extensive_size=None,
         minmax = None,
         ylabel = None,
-        zero_alpha = 1
+        zero_alpha = 1,
+        cmap = "viridis"
     ):
         """Shows a plot of the network
 
@@ -1071,6 +1085,11 @@ class Visuals(object):
         zero_alpha: float
             Alpha value to paint certain edges transparent. Look at docstring
             of paint_edges_extensive_sizes for more information
+        cmap : str, optional
+            Name of the colormap to use for visualization (default='viridis').
+            Common options include 'viridis', 'coolwarm', 'RdYlGn', 'plasma', 
+            'Blues'. For temperature data, 'coolwarm' or 'RdYlGn' provide 
+            intuitive red=hot, blue=cold color semantics.
 
         Returns
         -------
@@ -1159,7 +1178,8 @@ class Visuals(object):
                 generic_intensive_size=generic_intensive_size,
                 generic_extensive_size=generic_extensive_size,
                 minmax=minmax,
-                zero_alpha=zero_alpha
+                zero_alpha=zero_alpha,
+                cmap=cmap,
             )
         else:
             ax = self.create_plot_simple(ax, scaling_factor=scaling_factor)
@@ -1230,7 +1250,7 @@ class Visuals(object):
             cond = None
         if cond is not None:
             ax1 = plt.subplot(gs[1])
-            self._add_color_scale(ax1,minmax,ylabel, label_size=label_size)
+            self._add_color_scale(ax1,minmax,ylabel, label_size=label_size,cmap=cmap)
 
         if timestamp:
             ax.text(0.0, 
@@ -1896,10 +1916,10 @@ class Visuals(object):
             width=None,
         )
         return ax
-    def _add_color_scale(self, ax1,minmax,ylabel, label_size):
+    def _add_color_scale(self, ax1,minmax,ylabel, label_size,cmap = "viridis"):
         # ax1 = plt.subplot(gs[1])
         norm = Normalize(minmax[0],minmax[1])
-        cb1 = mpl.colorbar.ColorbarBase(ax1, cmap=plt.get_cmap("viridis"), norm=norm, orientation="vertical")
+        cb1 = mpl.colorbar.ColorbarBase(ax1, cmap=plt.get_cmap(cmap), norm=norm, orientation="vertical")
         cb1.ax.set_ylabel(ylabel, labelpad=15)
         text = cb1.ax.yaxis.label
         font = mpl.font_manager.FontProperties(size=label_size)
@@ -1907,7 +1927,7 @@ class Visuals(object):
         cb1.ax.tick_params(labelsize=label_size)
         
 
-    def _paint_edges_extensive_sizes(self, ax,key,minmax,scaling_factor_diameter=25,zero_alpha=1):
+    def _paint_edges_extensive_sizes(self, ax,key,minmax,scaling_factor_diameter=25,zero_alpha=1,cmap = "viridis"):
         """
         Add the progression of extensive variables (e.g., mass flow) in color to the edges.
 
@@ -1931,6 +1951,11 @@ class Visuals(object):
             Useful to make pipes with same values transparent. For example if velocity deviations shall
             be plotted, the pipes with zero deviation can be made transparent to highlight smaller pipes
             with high deviations
+        cmap : str, optional
+            Name of the colormap to use for visualization (default='viridis').
+            Common options include 'viridis', 'coolwarm', 'RdYlGn', 'plasma', 
+            'Blues'. For temperature data, 'coolwarm' or 'RdYlGn' provide 
+            intuitive red=hot, blue=cold color semantics.
 
         Returns
         -------
@@ -1966,14 +1991,14 @@ class Visuals(object):
                 raise KeyError(f"Edge {edge} has no {key}. Check assignment of {key} to edges")
             self.logger.debug(f"{key} found for {edge}: {value}")
         
-        #3 Choose color from "viridis"-palette for the certain mass flow of the edge
+        #3 Choose color from colormap-palette for the certain mass flow of the edge
             #3.1 Define alpha channel to make the color transparent if the value is close to zero
             eps = 1e-6
             if value < minmax[0] + eps:
                 alpha_channel = zero_alpha
             else:
                 alpha_channel = 1
-            color = plt.get_cmap("viridis")(Normalize(minmax[0],minmax[1])(abs(value)),alpha_channel)
+            color = plt.get_cmap(cmap)(Normalize(minmax[0],minmax[1])(abs(value)),alpha_channel)
         
         #4 Summarize color and geometry to a LineCollection
             lc = LineCollection([line], colors=[color], linewidths=linewidth*scaling_factor_diameter)
@@ -2021,7 +2046,7 @@ class Visuals(object):
         #             fontsize=4,
         #         )
 
-    def _paint_edges_intensive_sizes(self, ax, key, minmax,scaling_factor_diameter=25):
+    def _paint_edges_intensive_sizes(self, ax, key, minmax,scaling_factor_diameter=25,cmap = "viridis"):
         """
         Add the progression of intensive variables (e.g., temperature) in color to the edges.
 
@@ -2040,6 +2065,11 @@ class Visuals(object):
             Format: [minimum, maximum]
         scaling_factor_diameter : float
             Scaling factor for the edge diameter.
+        cmap : str, optional
+            Name of the colormap to use for visualization (default='viridis').
+            Common options include 'viridis', 'coolwarm', 'RdYlGn', 'plasma', 
+            'Blues'. For temperature data, 'coolwarm' or 'RdYlGn' provide 
+            intuitive red=hot, blue=cold color semantics.
 
         Returns
         -------
@@ -2106,7 +2136,7 @@ class Visuals(object):
                 #LineCollection with min-max values gets defined
             lc = LineCollection(
                     segments,
-                    cmap=plt.get_cmap("viridis"),
+                    cmap=plt.get_cmap(cmap),
                     norm=Normalize(minmax[0], minmax[1]),
                 )
                 #Values like temperature get assigned to LineCollection which results 


### PR DESCRIPTION
Solves #50 
This pull request introduces enhancements to the visualization functionality in the `uesgraphs` library and updates the interactive plot `examples\interactive2.ipynb` notebook to reflect these changes. The primary focus is on adding support for customizable colormaps in network visualizations, improving flexibility and user experience.

### Visualization Enhancements
* `uesgraphs/visuals.py`:
  - Added a `cmap` parameter to the `create_plot` and `show_network` functions, allowing users to specify the colormap for visualizations. Default is set to `'viridis'`. [[1]](diffhunk://#diff-74d5650907a589f1f47a79064e43cda038004f30c5b10c5d996979f31881ad8dL313-R314) [[2]](diffhunk://#diff-74d5650907a589f1f47a79064e43cda038004f30c5b10c5d996979f31881ad8dL990-R1004)
  - Updated internal methods to utilize the `cmap` parameter for various visualization components such as edges and color scales. [[1]](diffhunk://#diff-74d5650907a589f1f47a79064e43cda038004f30c5b10c5d996979f31881ad8dL744-R750) [[2]](diffhunk://#diff-74d5650907a589f1f47a79064e43cda038004f30c5b10c5d996979f31881ad8dL800-R821) [[3]](diffhunk://#diff-74d5650907a589f1f47a79064e43cda038004f30c5b10c5d996979f31881ad8dL1233-R1253)

### Notebook Updates
* `uesgraphs/examples/interactive2.ipynb`:
  - Added a dropdown widget for colormap selection in the interactive interface. This enables users to dynamically change the colormap used in visualizations. [[1]](diffhunk://#diff-c500d388838b3148ff0e3761c20d54bb899f7f86b9b3dadd7ee32cdb95e1f48aR294-R300) [[2]](diffhunk://#diff-c500d388838b3148ff0e3761c20d54bb899f7f86b9b3dadd7ee32cdb95e1f48aL619-R619)
  - Replaced hardcoded paths with dynamically constructed paths using `os.path.join` for better portability.
  - Updated the `aixlib_version` parameter in the example to `2.1.0` to reflect the latest version.