### PR TITLE
Bugfix process_parquet

### DIFF
--- a/uesgraphs/analyze.py
+++ b/uesgraphs/analyze.py
@@ -60,7 +60,9 @@ def process_parquet_file(file_path: str, filter_list: List[str],
         chunk_size: Number of rows to process at once
     """
     # Read parquet file metadata to get columns
-    parquet_file = pq.ParquetFile(file_path)
+    parquet_file = pq.ParquetFile(file_path,
+                                  thrift_string_size_limit=500_000_000,
+                                  thrift_container_size_limit=500_000_000)
     all_columns = parquet_file.schema.names
     
     # Pre-filter columns based on filter_list to reduce memory usage


### PR DESCRIPTION
This pull request includes a single change to the `process_parquet_file` function in `uesgraphs/analyze.py`. The change updates the `pq.ParquetFile` instantiation to include `thrift_string_size_limit` and `thrift_container_size_limit` parameters, both set to 500,000,000, to handle larger Parquet files more effectively.
