### PR TITLE
Minor Bugfix in input file creation

### DIFF
--- a/uesgraphs/systemmodels/systemmodelheating.py
+++ b/uesgraphs/systemmodels/systemmodelheating.py
@@ -2181,7 +2181,7 @@ class SystemModelHeating(UESGraph):
 
         content = input_template.render_unicode(
             name_variable=name_variable,
-            rows=len(values),
+            rows=min(len(time), len(values)),
             time=time,
             values=values,
             digits=digits,


### PR DESCRIPTION
The template for the input requires a row argument which states the numer of rows that are written in the file. While the max number of rows depend on either the number of time indices or number of values available the shape is just determined by the number of available values. Changed the calculation of the row attribute so that its always equal to the minimum length of either times or values